### PR TITLE
Update ubuntu+py versions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,12 +4,12 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.6'
+          python-version: '3.7.13'
           cache: 'pip'
       - run: pip install -r requirements.txt
 


### PR DESCRIPTION
Old ubuntu 20.04 causes issues with pipeline enforcer now, upgraded to 22.04 that is fine, but the python version isn't supported for that os version so changed to one that is and still works. All tested and working as of 11th June 2024